### PR TITLE
added configuration parameter for http strict entity timeout

### DIFF
--- a/src/main/resources/reference.conf
+++ b/src/main/resources/reference.conf
@@ -107,3 +107,7 @@ pdnd-uservice-rest-template {
   number-of-events-before-snapshot = 1000
   persistence = "memory"
 }
+
+http {
+  entity-to-strict-timeout = 15 seconds
+}

--- a/template/scala-akka-http-server/controller.mustache
+++ b/template/scala-akka-http-server/controller.mustache
@@ -20,6 +20,7 @@ import scala.concurrent.duration._
 import scala.jdk.CollectionConverters._
 import scala.util.{Failure, Success, Try}
 import java.io.{File, FileOutputStream}
+import com.typesafe.config.{Config, ConfigFactory}
 
 class Controller({{#apiInfo}}{{#apis}}{{#operations}}{{classVarName}}: {{classname}}{{^-last}}, {{/-last}}{{/operations}}{{/apis}}{{/apiInfo}}, validationExceptionToRoute: Option[ValidationException => Route] = None)(implicit system: ActorSystem) {
 
@@ -29,6 +30,7 @@ class Controller({{#apiInfo}}{{#apis}}{{#operations}}{{classVarName}}: {{classna
       resource.transferTo(new FileOutputStream(tmpFile))
       private val api = new OpenApi3Parser().parse(tmpFile, true)
       private val validator = new RequestValidator(api)
+      private val strictnessTimeout = FiniteDuration(ConfigFactory.load().getDuration("http.entity-to-strict-timeout").toSeconds, SECONDS)
 
       def validationFunction(httpRequest: HttpRequest)(route: Route): Route = {
         if (!(validationExceptionToRoute.isDefined && !httpRequest.uri.toString.contains("swagger-ui")))
@@ -79,7 +81,7 @@ class Controller({{#apiInfo}}{{#apis}}{{#operations}}{{classVarName}}: {{classna
       }
 
   lazy val routes: Route = pathPrefix("{{projectName}}" / "{{appVersion}}") {
-    toStrictEntity(15.seconds) {
+    toStrictEntity(strictnessTimeout) {
       extractRequest {
         request =>
           validationFunction(request){


### PR DESCRIPTION
Small improvement to `controller.mustache`: it adds a configuration parameter to customize `toStrictEntity` timeout.
If no override is performed, this parameter fallbacks to the default one written in `reference.conf` (15 seconds).