### PR TITLE
project versioning improved

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -1,4 +1,4 @@
-import scala.sys.process.Process
+import ProjectSettings.ProjectFrom
 
 ThisBuild / scalaVersion := "2.13.5"
 ThisBuild / organization := "it.pagopa"
@@ -58,7 +58,7 @@ lazy val generated = project
   .in(file("generated"))
   .settings(
     scalacOptions := Seq()
-  ).enablePlugins(BuildInfoPlugin)
+  ).setupBuildInfo
 
 lazy val client = project
   .in(file("client"))
@@ -106,6 +106,7 @@ lazy val root = (project in file("."))
   )
   .aggregate(client)
   .dependsOn(generated)
-  .enablePlugins(BuildInfoPlugin, JavaAppPackaging, JavaAgent)
+  .enablePlugins(JavaAppPackaging, JavaAgent)
+  .setupBuildInfo
 
 javaAgents += "io.kamon" % "kanela-agent" % "1.0.7"

--- a/kubernetes/config
+++ b/kubernetes/config
@@ -12,4 +12,7 @@ repository=$DOCKER_REPO
 
 name=$(cat $SCRIPT_PATH/../build.sbt | grep "name :=" | awk -F:= '{ print $2 }' | sed 's/\"//' | sed 's/\",//' | sed 's/ //' | tr '[:upper:]' '[:lower:]' | grep -v client)
 
-version=$($SCRIPT_PATH/../version.sh)
+#getting version from sbt
+cd ..
+version=$(sbt -Dsbt.log.noformat=true 'inspect actual version' | grep "Setting: java.lang.String" | cut -d '=' -f2 | tr -d ' ')
+cd $SCRIPT_PATH

--- a/project/ProjectSettings.scala
+++ b/project/ProjectSettings.scala
@@ -1,0 +1,61 @@
+import sbt.{Project, ThisBuild}
+import sbtbuildinfo.BuildInfoKeys.buildInfoOptions
+import sbtbuildinfo.BuildInfoPlugin.autoImport.{BuildInfoKey, buildInfoKeys}
+import sbtbuildinfo.{BuildInfoOption, BuildInfoPlugin}
+import sbtdynver.DynVerPlugin.autoImport.{dynverCurrentDate, dynverInstance, dynverSeparator, dynverSonatypeSnapshots}
+import sbtdynver.GitDescribeOutput
+
+import java.util.Date
+import scala.sys.process.Process
+import scala.util.Try
+
+/** Allows customizations of build.sbt syntax.
+  */
+object ProjectSettings {
+
+  private val describeOutput: Option[GitDescribeOutput] = sbtdynver.DynVer.getGitDescribeOutput(new java.util.Date)
+
+  //TODO since Git 2.22 we could use the following command instead: git branch --show-current
+  private val currentBranch: Option[String] = Try(
+    Process(s"git rev-parse --abbrev-ref HEAD").lineStream_!.head
+  ).toOption
+  private val commitSha: Option[String] = Try(Process(s"git rev-parse --short HEAD").lineStream_!.head).toOption
+
+  private def getInterfaceVersion(date: Date) = {
+    val semver = raw"([1-9]\d*)\.(\d+)\.(\d+).*".r
+    sbtdynver.DynVer.version(date) match {
+      case semver(major, minor, _*) =>
+        s"$major.$minor"
+      case _ =>
+        "wrong-version"
+    }
+  }
+
+  //lifts some useful data in BuildInfo instance
+  val buildInfoExtra = Seq[BuildInfoKey](
+    "ciBuildNumber"       -> sys.env.get("BUILD_NUMBER"),
+    "commitSha"           -> commitSha,
+    "headDistanceFromTag" -> describeOutput.map(_.commitSuffix.distance),
+    "tag"                 -> describeOutput.map(_.ref.dropPrefix),
+    "currentBranch"       -> currentBranch,
+    BuildInfoKey.map(dynverInstance) { case (_, v) => "isDirty" -> v.isDirty },
+    BuildInfoKey.map(dynverInstance) { case (_, v) => "isSnapshot" -> v.isSnapshot },
+    BuildInfoKey.map(dynverInstance) { case (_, v) => "isVersionStable" -> v.isVersionStable },
+    BuildInfoKey.map(dynverCurrentDate) { case (_, v) => "interfaceVersion" -> getInterfaceVersion(v) }
+  )
+
+  /** Extention methods for sbt Project instances.
+    * @param project
+    */
+  implicit class ProjectFrom(project: Project) {
+    def setupBuildInfo: Project = {
+      project
+        .enablePlugins(BuildInfoPlugin)
+        .settings(ThisBuild / dynverSonatypeSnapshots := true)
+        .settings(ThisBuild / dynverSeparator := "-")
+        .settings(buildInfoKeys ++= buildInfoExtra)
+        .settings(buildInfoOptions += BuildInfoOption.BuildTime)
+        .settings(buildInfoOptions += BuildInfoOption.ToJson)
+    }
+  }
+}

--- a/src/main/scala/it/pagopa/pdnd/uservice/resttemplate/server/impl/Main.scala
+++ b/src/main/scala/it/pagopa/pdnd/uservice/resttemplate/server/impl/Main.scala
@@ -48,7 +48,7 @@ object Main extends App {
         val cluster = Cluster(context.system)
 
         context.log.error(
-          "Started [" + context.system + "], cluster.selfAddress = " + cluster.selfMember.address + ", version = " + buildinfo.BuildInfo.version +")"
+          "Started [" + context.system + "], cluster.selfAddress = " + cluster.selfMember.address + ", build information = " + buildinfo.BuildInfo.toString +")"
         )
 
         val sharding: ClusterSharding = ClusterSharding(context.system)

--- a/template/scala-akka-http-server/controller.mustache
+++ b/template/scala-akka-http-server/controller.mustache
@@ -6,7 +6,7 @@ import akka.http.scaladsl.server.Route
 {{/operations}}{{/apis}}{{/apiInfo}}
 import akka.http.scaladsl.server.Directives._
 import akka.actor.ActorSystem
-import akka.http.scaladsl.model.{HttpEntity, HttpMethods, HttpRequest}
+import akka.http.scaladsl.model.{ContentTypes, HttpEntity, HttpMethods, HttpRequest}
 import akka.stream.scaladsl.Sink
 import org.openapi4j.core.validation.ValidationException
 import org.openapi4j.operation.validator.model.Request.Method
@@ -26,19 +26,10 @@ import scala.collection.mutable
 
 class Controller({{#apiInfo}}{{#apis}}{{#operations}}{{classVarName}}: {{classname}}{{^-last}}, {{/-last}}{{/operations}}{{/apis}}{{/apiInfo}}, validationExceptionToRoute: Option[ValidationException => Route] = None)(implicit system: ActorSystem) {
 
-        def getInterfaceVersion = {
-          val semver = raw"([1-9]\d*)\.(\d+)\.(\d+).*".r
-          buildinfo.BuildInfo.version match {
-            case semver(major, minor, _*) =>
-              s"$major.$minor"
-            case _ =>
-              "wrong-version"
-          }
-        }
-
+        val interfaceVersion = buildinfo.BuildInfo.interfaceVersion
         private val mf = new DefaultMustacheFactory
         val writer =
-        mf.compile("interface-specification.yml").execute(new StringWriter(), mutable.HashMap("version" -> getInterfaceVersion).asJava).asInstanceOf[StringWriter]
+        mf.compile("interface-specification.yml").execute(new StringWriter(), mutable.HashMap("version" -> interfaceVersion).asJava).asInstanceOf[StringWriter]
         writer.flush()
         writer.close()
         private val tmpFile = File.createTempFile("tmp", "interface-specification.yml")
@@ -49,9 +40,10 @@ class Controller({{#apiInfo}}{{#apis}}{{#operations}}{{classVarName}}: {{classna
         private val api = new OpenApi3Parser().parse(tmpFile, true)
         private val validator = new RequestValidator(api)
         private val strictnessTimeout = FiniteDuration(ConfigFactory.load().getDuration("http.entity-to-strict-timeout").toSeconds, SECONDS)
+        private val validationsWhitelist: List[String] = List("swagger-ui", "build-info")
 
       def validationFunction(httpRequest: HttpRequest)(route: Route): Route = {
-        if (!(validationExceptionToRoute.isDefined && !httpRequest.uri.toString.contains("swagger-ui")))
+        if (!(validationExceptionToRoute.isDefined && !validationsWhitelist.exists(httpRequest.uri.toString.contains(_))))
           route
         else {
           val builder = new DefaultRequest.Builder(httpRequest.uri.toString(), httpRequest.method match {
@@ -98,7 +90,17 @@ class Controller({{#apiInfo}}{{#apis}}{{#operations}}{{classVarName}}: {{classna
           }
       }
 
-  lazy val routes: Route = pathPrefix("{{projectName}}" / getInterfaceVersion) {
+  /**
+  * Exposes build information of this project.
+  */
+  def getBuildInfo: Route =
+    path("{{projectName}}" / "build-info") {
+      get {
+        complete(HttpEntity(ContentTypes.`application/json`, buildinfo.BuildInfo.toJson))
+      }
+   }
+
+  lazy val routes: Route = getBuildInfo ~ pathPrefix("{{projectName}}" / interfaceVersion) {
     toStrictEntity(strictnessTimeout) {
       extractRequest {
         request =>


### PR DESCRIPTION
this PR aims to:

- making buildInfo configuration more fluent by the introduction of `ProjectSettings` singleton;
- move the interfaceVersion calculation in the `ProjectSettings`
- making build information available as a REST route (**GET** `/build-info`) exposed via Controller (see `controller.mustache`);
- adapt `kubernetes/config` CLI command to work seamlessly within our CI for retrieving actual build version;
- logging build information at application startup. 

---

At application compilation, a BuildInfo instance is created. It holds the following build information data:

```scala
  /** Project name  e.g.: "pdnd-uservice-rest-template" */
  val name: String
  /** Project version, as retrieved by DynVer e.g.: "0.0.0-95-96e2e8d4-20210811-1431-SNAPSHOT" */
  val version: String 
  /** Interface version, represents the version value added to REST routes e.g.: "1.0" */
  val interfaceVersion: String
  /** Scala version e.g.: "2.13.5" */
  val scalaVersion: String
  /** SBT version e.g.: "1.5.5" */
  val sbtVersion: String 
  /** The Continuos Integration build number, e.g.: scala.Some("123") */
  val ciBuildNumber: scala.Option[String] 
  /** A flag to assess if the current is a snapshot version */
  val isSnapshot: scala.Boolean
  /** Short version of the latest commit SHA, retrieved via the GIT command, e.g.: scala.Some("96e2e8d") */
  val commitSha: scala.Option[String]
  /** Current commits distance from the latest tag, e.g.: scala.Some(95) */
  val headDistanceFromTag: scala.Option[scala.Int]
  /** The latest tag, if any. Otherwise it returns the first 8 digits of the commit SHA (as per DynVer behavior), e.g.: scala.Some("96e2e8d4") */
  val tag: scala.Option[String]
  /** Current branch name, e.g.: scala.Some("develop") */
  val currentBranch: scala.Option[String] 
  /** A flag to assess if the current is a dirty version */
  val isDirty
  /** Dual flag of isDirty: is true when the version is stable */
  val isVersionStable
  /** Build time as string, e.g.: "2021-08-11 14:31:33.707+0200" */
  val builtAtString: String
  /** Built time in millis,  e.g.: 1628685093707L */
  val builtAtMillis: scala.Long

```