### PR TITLE
Include file openapitools.json

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,6 +10,5 @@ metals.sbt
 .openapi-generator
 generated/src/
 client/src/
-openapitools.json
 .DS_Store
 client/project/build.properties


### PR DESCRIPTION
As per doc:

```
If you have installed the package locally and executed the command openapi-generator-cli at least once, you will find a new file called openapitools.json along with the package.json. Please add this file to your VCS.
```