### PR TITLE
Draft: [PIN-1040] Aligning template to de-facto standard

### DIFF
--- a/template/scala-akka-http-client/model.mustache
+++ b/template/scala-akka-http-client/model.mustache
@@ -8,7 +8,9 @@ import {{invokerPackage}}.ApiModel
 
 {{#models}}
 {{#model}}
+
 {{^isEnum}}
+
 
 case class {{classname}} (
   {{#vars}}
@@ -54,6 +56,15 @@ object {{classname}} {
   {{/values}}
   {{/allowableValues}}
 
+  def fromValue(value: String): Either[Throwable, {{classname}}] =
+    value match {
+    {{#allowableValues}}
+    {{#values}}
+       case "{{.}}" => Right({{.}})
+    {{/values}}
+    {{/allowableValues}}
+       case other => Left(new RuntimeException(s"Unable to decode value $other"))
+    }
 }
 
 {{/isEnum}}

--- a/template/scala-akka-http-client/serializers.mustache
+++ b/template/scala-akka-http-client/serializers.mustache
@@ -1,0 +1,102 @@
+package {{invokerPackage}}
+
+{{#java8}}
+    import java.time.{LocalDate, LocalDateTime, OffsetDateTime, ZoneId}
+    import java.time.format.DateTimeFormatter
+{{/java8}}
+{{#joda}}
+    import org.joda.time.format.ISODateTimeFormat
+    import org.joda.time.{LocalDate, DateTime}
+{{/joda}}
+import org.json4s.{Serializer, CustomSerializer, JNull}
+import org.json4s.ext.JavaTypesSerializers
+import org.json4s.JsonAST.JString
+
+import scala.util.Try
+
+{{#models}}
+    {{#model}}
+        {{#isEnum}}
+            import {{modelPackage}}.{{classname}}
+        {{/isEnum}}
+    {{/model}}
+{{/models}}
+
+object Serializers {
+
+{{#java8}}
+    case object DateTimeSerializer extends CustomSerializer[OffsetDateTime]( _ => ( {
+    case JString(s) =>
+    Try(OffsetDateTime.parse(s, DateTimeFormatter.ISO_OFFSET_DATE_TIME)) orElse
+    Try(LocalDateTime.parse(s).atZone(ZoneId.systemDefault()).toOffsetDateTime) getOrElse null
+    }, {
+    case d: OffsetDateTime =>
+    JString(d.format(DateTimeFormatter.ISO_OFFSET_DATE_TIME))
+    }))
+
+    case object LocalDateSerializer extends CustomSerializer[LocalDate]( _ => ( {
+    case JString(s) => LocalDate.parse(s)
+    }, {
+    case d: LocalDate =>
+    JString(d.format(DateTimeFormatter.ISO_LOCAL_DATE))
+    }))
+{{/java8}}
+{{#joda}}
+    case object DateTimeSerializer extends CustomSerializer[DateTime](_ => ( {
+    case JString(s) =>
+    ISODateTimeFormat.dateOptionalTimeParser().parseDateTime(s)
+    }, {
+    case d: DateTime => JString(ISODateTimeFormat.dateTime().print(d))
+    }))
+
+    case object LocalDateSerializer extends CustomSerializer[LocalDate]( _ => ( {
+    case JString(s) => ISODateTimeFormat.localDateParser().parseLocalDate(s)
+    }, {
+    case d: LocalDate => JString(ISODateTimeFormat.date().print(d))
+    }))
+{{/joda}}
+
+
+{{#models}}
+    {{#model}}
+        {{#isEnum}}
+
+
+            object {{classname}}Serializer
+            extends CustomSerializer[{{classname}}](formats =>
+            (
+            {
+            {{#allowableValues}}
+                {{#values}}
+                    case JString("{{.}}") => {{classname}}.{{.}}
+                {{/values}}
+            {{/allowableValues}}
+            },
+            {
+            {{#allowableValues}}
+                {{#values}}
+                    case {{classname}}.{{.}} => JString("{{.}}")
+                {{/values}}
+            {{/allowableValues}}
+            }
+            )
+            )
+
+
+        {{/isEnum}}
+    {{/model}}
+{{/models}}
+
+val enumSerializers = Seq(
+{{#models}}
+    {{#model}}
+        {{#isEnum}}
+            {{classname}}Serializer,
+        {{/isEnum}}
+    {{/model}}
+{{/models}}
+)
+
+def all: Seq[Serializer[_]] = JavaTypesSerializers.all ++ enumSerializers :+ DateTimeSerializer :+ LocalDateSerializer
+
+}

--- a/template/scala-akka-http-server/api.mustache
+++ b/template/scala-akka-http-server/api.mustache
@@ -1,14 +1,22 @@
 package {{package}}
 
+import akka.event.Logging
+import akka.http.scaladsl.model.HttpRequest
+import akka.http.scaladsl.server.directives.{DebuggingDirectives, LogEntry}
+import akka.http.scaladsl.server.{Directive0, Directive1, Route, RouteResult}
 import akka.http.scaladsl.server.Directives._
 import akka.http.scaladsl.model.StatusCodes
-import akka.http.scaladsl.server.{Directive1, Route}
+import org.slf4j.{Logger, LoggerFactory}
+import ch.qos.logback.classic.LoggerContext
+import it.pagopa.pdnd.interop.commons.logging.ContextFieldsToLog
+import it.pagopa.pdnd.interop.commons.utils.UID
+import it.pagopa.pdnd.interop.commons.utils.CORRELATION_ID_HEADER
 {{^pathMatcherPatterns.isEmpty}}import akka.http.scaladsl.server.{PathMatcher, PathMatcher1}
 {{/pathMatcherPatterns.isEmpty}}
 import akka.http.scaladsl.marshalling.ToEntityMarshaller
 {{#hasMarshalling}}
-    import akka.http.scaladsl.unmarshalling.FromEntityUnmarshaller
-    import akka.http.scaladsl.unmarshalling.FromStringUnmarshaller
+import akka.http.scaladsl.unmarshalling.FromEntityUnmarshaller
+import akka.http.scaladsl.unmarshalling.FromStringUnmarshaller
 {{/hasMarshalling}}
 {{#hasCookieParams}}import akka.http.scaladsl.model.headers.HttpCookiePair
 {{/hasCookieParams}}
@@ -38,10 +46,28 @@ import akka.http.scaladsl.server.directives.FileInfo
     {{#hasMarshalling}}import {{classVarName}}Marshaller._
     {{/hasMarshalling}}
 
+   private def logHttp(ctxs: Seq[(String, String)]): Directive0 = {
+       val contexts = ctxs.toMap
+       val context =
+         s"""[${contexts.get(UID).getOrElse("")}] [${contexts.get(CORRELATION_ID_HEADER).getOrElse("")}]"""
+       def logWithoutBody(req: HttpRequest): RouteResult => Option[LogEntry] = {
+         case RouteResult.Complete(res) =>
+           Some(LogEntry(s"${context} - Request ${req.uri} - Response ${res.status}", Logging.InfoLevel))
+         case RouteResult.Rejected(rej) =>
+           Some(LogEntry(s"${context} - Request ${req.uri} - Response ${rej}", Logging.InfoLevel))
+       }
+       DebuggingDirectives.logRequestResult(logWithoutBody _)
+     }
+
     lazy val route: Route =
     {{#operation}}
         path({{#vendorExtensions.x-paths}}{{#isText}}"{{/isText}}{{value}}{{#isText}}"{{/isText}}{{^-last}} / {{/-last}}{{/vendorExtensions.x-paths}}) { {{^pathParams.isEmpty}}({{#pathParams}}{{paramName}}{{^-last}}, {{/-last}}{{/pathParams}}) => {{/pathParams.isEmpty}}
-        {{#lambda.lowercase}}{{httpMethod}}{{/lambda.lowercase}} { wrappingDirective { implicit contexts => {{^queryParams.isEmpty}}
+        {{#lambda.lowercase}}{{httpMethod}}{{/lambda.lowercase}} {
+        optionalHeaderValueByName(CORRELATION_ID_HEADER) { correlationId =>
+               val contextsDirective = wrappingDirective.map(contexts => contexts.prepended((CORRELATION_ID_HEADER, correlationId.getOrElse(""))))
+               contextsDirective { implicit contexts =>
+               logHttp(contexts) {
+            {{^queryParams.isEmpty}}
             parameters({{#queryParams}}"{{baseName}}".as[{{dataType}}]{{^required}}.?{{#vendorExtensions.x-has-default-value}}({{{defaultValue}}}){{/vendorExtensions.x-has-default-value}}{{/required}}{{^-last}}, {{/-last}}{{/queryParams}}) { ({{#queryParams}}{{paramName}}{{^-last}}, {{/-last}}{{/queryParams}}) =>{{/queryParams.isEmpty}} {{^headerParams.isEmpty}}
             {{#headerParams}}{{#required}}headerValueByName{{/required}}{{^required}}optionalHeaderValueByName{{/required}}("{{baseName}}") { {{paramName}} => {{/headerParams}}{{/headerParams.isEmpty}}{{^cookieParams.isEmpty}}
             {{#cookieParams}}{{#required}}cookie({{/required}}{{^required}}optionalCookie({{/required}}"{{baseName}}"){ {{paramName}} => {{/cookieParams}}{{/cookieParams.isEmpty}}{{#isMultipart}}
@@ -49,7 +75,9 @@ import akka.http.scaladsl.server.directives.FileInfo
             }{{/cookieParams.isEmpty}}{{^headerParams.isEmpty}}
             }{{/headerParams.isEmpty}}{{^queryParams.isEmpty}}
             }{{/queryParams.isEmpty}}
-        }
+            }
+            }
+          }
         }
         }{{^-last}} ~{{/-last}}
     {{/operation}}
@@ -72,8 +100,8 @@ import akka.http.scaladsl.server.directives.FileInfo
         {{#responses}}   * {{#code}}Code: {{.}}{{/code}}{{#message}}, Message: {{.}}{{/message}}{{#dataType}}, DataType: {{.}}{{/dataType}}
         {{/responses}}
         */
-        def {{operationId}}({{> operationParam}})
-        (implicit contexts: Seq[(String, String)]{{^vendorExtensions.x-specific-marshallers.isEmpty}}, {{#vendorExtensions.x-specific-marshallers}}toEntityMarshaller{{varName}}: ToEntityMarshaller[{{dataType}}]{{^-last}}, {{/-last}}{{/vendorExtensions.x-specific-marshallers}}{{/vendorExtensions.x-specific-marshallers.isEmpty}}): Route
+        def {{operationId}}({{> operationParam}}){{^vendorExtensions.x-specific-marshallers.isEmpty}}
+            (implicit {{#vendorExtensions.x-specific-marshallers}}toEntityMarshaller{{varName}}: ToEntityMarshaller[{{dataType}}]{{^-last}}, {{/-last}}{{/vendorExtensions.x-specific-marshallers}}, contexts: Seq[(String, String)]){{/vendorExtensions.x-specific-marshallers.isEmpty}}: Route
 
     {{/operation}}
     }

--- a/template/scala-akka-http-server/controller.mustache
+++ b/template/scala-akka-http-server/controller.mustache
@@ -1,34 +1,28 @@
 package {{invokerPackage}}
 
-import akka.http.scaladsl.Http
 import akka.http.scaladsl.server.Route
 {{#apiInfo}}{{#apis}}{{#operations}}import {{package}}.{{classname}}
 {{/operations}}{{/apis}}{{/apiInfo}}
 import akka.http.scaladsl.server.Directives._
 import akka.actor.ActorSystem
 import akka.http.scaladsl.model.{ContentTypes, HttpEntity, HttpMethods, HttpRequest}
-import akka.stream.scaladsl.Sink
-import org.openapi4j.core.validation.ValidationException
-import org.openapi4j.operation.validator.model.Request.Method
-import org.openapi4j.operation.validator.model.impl.{Body, DefaultRequest}
-import org.openapi4j.operation.validator.validation.RequestValidator
-import org.openapi4j.parser.OpenApi3Parser
+import com.atlassian.oai.validator.OpenApiInteractionValidator
+import com.atlassian.oai.validator.model.Request.Method
+import com.atlassian.oai.validator.model.SimpleRequest.Builder
+import com.atlassian.oai.validator.report.ValidationReport
 import com.github.mustachejava.DefaultMustacheFactory
 
-import scala.concurrent.Await
-import scala.concurrent.duration.Duration
 import scala.concurrent.duration._
 import scala.jdk.CollectionConverters._
 import scala.util.{Failure, Success, Try}
-import java.io.{BufferedWriter, File, FileOutputStream, FileWriter, StringWriter}
-import scala.collection.mutable
+import java.io.{BufferedWriter, File, FileWriter, StringWriter}
 
-class Controller({{#apiInfo}}{{#apis}}{{#operations}}{{classVarName}}: {{classname}}{{^-last}}, {{/-last}}{{/operations}}{{/apis}}{{/apiInfo}}, validationExceptionToRoute: Option[ValidationException => Route] = None)(implicit system: ActorSystem) {
+class Controller({{#apiInfo}}{{#apis}}{{#operations}}{{classVarName}}: {{classname}}{{^-last}}, {{/-last}}{{/operations}}{{/apis}}{{/apiInfo}}, validationExceptionToRoute: Option[ValidationReport => Route] = None)(implicit system: ActorSystem) {
 
         val interfaceVersion = buildinfo.BuildInfo.interfaceVersion
         private val mf = new DefaultMustacheFactory
         val writer =
-        mf.compile("interface-specification.yml").execute(new StringWriter(), mutable.HashMap("version" -> interfaceVersion).asJava).asInstanceOf[StringWriter]
+        mf.compile("interface-specification.yml").execute(new StringWriter(), Map("version" -> interfaceVersion).asJava).asInstanceOf[StringWriter]
         writer.flush()
         writer.close()
         private val tmpFile = File.createTempFile("tmp", "interface-specification.yml")
@@ -36,8 +30,12 @@ class Controller({{#apiInfo}}{{#apis}}{{#operations}}{{classVarName}}: {{classna
         val w = new BufferedWriter(new FileWriter(tmpFile))
         w.write(writer.toString)
         w.close()
-        private val api = new OpenApi3Parser().parse(tmpFile, true)
-        private val validator = new RequestValidator(api)
+
+        private val validator: OpenApiInteractionValidator =
+           OpenApiInteractionValidator
+           .createForSpecificationUrl(tmpFile.getPath)
+           .withBasePathOverride(s"{{projectName}}/${interfaceVersion}")
+           .build
         private val strictnessTimeout = FiniteDuration({{entityStrictnessTimeout}}, SECONDS)
         private val validationsWhitelist: List[String] = List("swagger-ui", "build-info")
 
@@ -45,7 +43,7 @@ class Controller({{#apiInfo}}{{#apis}}{{#operations}}{{classVarName}}: {{classna
         if (!(validationExceptionToRoute.isDefined && !validationsWhitelist.exists(httpRequest.uri.toString.contains(_))))
           route
         else {
-          val builder = new DefaultRequest.Builder(httpRequest.uri.toString(), httpRequest.method match {
+          val builder = new Builder(httpRequest.method match {
             case HttpMethods.POST =>
               Method.POST
             case HttpMethods.GET =>
@@ -61,33 +59,34 @@ class Controller({{#apiInfo}}{{#apis}}{{#operations}}{{classVarName}}: {{classna
             case HttpMethods.PATCH =>
               Method.PATCH
             case HttpMethods.TRACE =>
-              Method.TRACE  
+              Method.TRACE
             case _ =>
               Method.GET
-          })
-          val entity = httpRequest.entity.asInstanceOf[HttpEntity.Strict]
-          val contentType = entity.getContentType().toString
-          val requestHeaders = ("Content-Type", contentType) :: httpRequest.
-            headers.
-            map(
-              header =>
-                (header.name(), header.value)
-            ).
-            toList
+        },
+        httpRequest.uri.toRelative.path.toString()
+      )
+      val entity      = httpRequest.entity.asInstanceOf[HttpEntity.Strict]
+      val contentType = entity.getContentType().toString
+      val requestHeaders =
+        ("Content-Type", contentType) :: httpRequest.headers.map(header => (header.name(), header.value)).toList
 
-          val headers = (("Content-Type", contentType) :: requestHeaders).map(p => (p._1, Seq(p._2).asJava: java.util.Collection[String])).toMap.asJava
+      val headers = ("Content-Type", contentType) :: requestHeaders
 
-          val validatingRequest = builder.body(Body.from(entity.data.utf8String)).headers(headers).build()
-            Try(validator.validate(validatingRequest)) match {
-               case Failure(e: ValidationException) =>
-                 validationExceptionToRoute.fold[Route](complete((400, e.getMessage)))(_ (e))
-               case Failure(e) =>
-                 throw e
-               case Success(_) =>
-                 route
-              }
-          }
+      val uri = httpRequest.uri.query().toMap
+      val headedBuilder     = headers.foldLeft(builder)((b, header) => b.withHeader(header._1, header._2))
+      val requestWithParams = uri.foldLeft(headedBuilder)((b, param) => b.withQueryParam(param._1, param._2))
+
+      val validatingRequest = requestWithParams.withBody(entity.data.utf8String).build()
+      Try(validator.validateRequest(validatingRequest)) match {
+        case Success(r) if r.hasErrors =>
+          validationExceptionToRoute.fold[Route](complete((400, r.getMessages.asScala.map(_.getMessage).mkString(", "))))(_(r))
+        case Failure(e) =>
+          throw e
+        case Success(_) =>
+          route
       }
+    }
+  }
 
   /**
   * Exposes build information of this project.
@@ -99,20 +98,20 @@ class Controller({{#apiInfo}}{{#apis}}{{#operations}}{{classVarName}}: {{classna
       }
    }
 
-     def swaggerRoute: Route =
-         pathPrefix("{{projectName}}" / interfaceVersion / "swagger") {
-           getFromResourceDirectory("swagger-ui") ~ getFromFile(tmpFile)
-     }
+   def swaggerRoute: Route =
+       pathPrefix("{{projectName}}" / interfaceVersion / "swagger") {
+         getFromResourceDirectory("swagger-ui") ~ getFromFile(tmpFile)
+   }
 
-  lazy val routes: Route = getBuildInfo ~ swaggerRoute ~ pathPrefix("{{projectName}}" / interfaceVersion) {
-    toStrictEntity(strictnessTimeout) {
-      extractRequest {
-        request =>
-          validationFunction(request){
-            {{#apiInfo}}{{#apis}}{{#operations}}{{classVarName}}.route {{^-last}} ~ {{/-last}}{{/operations}}{{/apis}}{{/apiInfo}}
-        }
-      }
-    }
-  }
+   lazy val routes: Route = getBuildInfo ~ swaggerRoute ~ pathPrefix("{{projectName}}" / interfaceVersion) {
+       toStrictEntity(strictnessTimeout) {
+         extractRequest {
+           request =>
+             validationFunction(request){
+               {{#apiInfo}}{{#apis}}{{#operations}}{{classVarName}}.route {{^-last}} ~ {{/-last}}{{/operations}}{{/apis}}{{/apiInfo}}
+           }
+         }
+       }
+     }
 
 }

--- a/template/scala-akka-http-server/model.mustache
+++ b/template/scala-akka-http-server/model.mustache
@@ -46,13 +46,51 @@ object {{classname}}Enums {
 {{/isEnum}}
 
 {{#isEnum}}
+
 sealed trait {{classname}}
 
-{{#allowableValues}}
-{{#values}}
-case object {{.}} extends {{classname}}
-{{/values}}
+object {{classname}} {
+  import spray.json._
+
+  {{#allowableValues}}
+  {{#values}}
+  case object {{.}} extends {{classname}}
+  {{/values}}
   {{/allowableValues}}
+
+  implicit object {{classname}}Format extends RootJsonFormat[{{classname}}] {
+      def write(obj: {{classname}}): JsValue =
+        obj match {
+  {{#allowableValues}}
+  {{#values}}
+           case {{.}} => JsString("{{.}}")
+  {{/values}}
+  {{/allowableValues}}
+        }
+
+      def read(json: JsValue): {{classname}} =
+        json match {
+  {{#allowableValues}}
+  {{#values}}
+           case JsString("{{.}}") => {{.}}
+  {{/values}}
+  {{/allowableValues}}
+          case unrecognized     => deserializationError(s"{{classname}} serialization error ${unrecognized.toString}")
+        }
+  }
+
+  def fromValue(value: String): Either[Throwable, {{classname}}] =
+    value match {
+    {{#allowableValues}}
+    {{#values}}
+       case "{{.}}" => Right({{.}})
+    {{/values}}
+    {{/allowableValues}}
+       case other => Left(new RuntimeException(s"Unable to decode value $other"))
+    }
+
+}
+
 {{/isEnum}}
 {{/model}}
 {{/models}}

--- a/template/scala-akka-http-server/multipart.mustache
+++ b/template/scala-akka-http-server/multipart.mustache
@@ -1,3 +1,4 @@
+
 formAndFiles({{#vendorExtensions.x-file-params}}FileField("{{baseName}}")){{/vendorExtensions.x-file-params}}{{^-last}} {{/-last}} { partsAndFiles => {{^vendorExtensions.x-file-params.isEmpty}}
     val routes : Try[Route] = for {
     {{#vendorExtensions.x-file-params}}{{baseName}} <- optToTry(partsAndFiles.files.get("{{baseName}}"), s"File {{baseName}} missing")


### PR DESCRIPTION
This PR alignes the mustache files in the template with the ones in [agreement-management](https://github.com/pagopa/pdnd-interop-uservice-agreement-management) that is considered (at least by @galales :D ) the de-facto standard that contains all the necessary modifications for a microservice to work.

In particular it contains:
- A serializers.mustache
- A proper factory method for Enums
- Logging in api.mustache
- Fixed serialization in model.mustache
- Validator was moved from log4j one to atlassian one
- Some reformatting

I ask you to review the PR with even more care than usual since it will be propagated to potentially all microservices
